### PR TITLE
Fix a CPU hog in OrientSocket.read()

### DIFF
--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -91,8 +91,8 @@ class OrientSocket(object):
             # or broken line issues because of
             """:see: https://docs.python.org/2/howto/sockets.html#when-sockets-die """
             try:
-                ready_to_read, ready_to_write, in_error = \
-                    select.select( [self._socket, ], [self._socket, ], [], 30 )
+                ready_to_read, _, in_error = \
+                    select.select( [self._socket, ], [], [self._socket, ], 30 )
             except select.error as e:
                 self.connected = False
                 raise e
@@ -113,9 +113,10 @@ class OrientSocket(object):
                     _len_to_read -= n_bytes
                 return bytes(buf)
 
-            if len(ready_to_write) > 0:
-                # nothing to send
-                pass
+            if len(in_error) > 0:
+                self._socket.close()
+                raise PyOrientConnectionException(
+                    "Socket error", [])
 
 
 def ByteToHex( byte_str ):


### PR DESCRIPTION
The call to `select.select( [self._socket, ], [self._socket, ], [], 30 )` always immediately returns because the socket is writable. In fact we want to read from it, but ready_to_read is empty so we immediately go back to the `select()` call ... The result is much system CPU time burnt inside `select()`.

The fix makes `select()` block until the socket is really readable or an error or control event happened. Also added code to report the error detected in `select()`.
